### PR TITLE
Upgrade databend version in tests and refactor them

### DIFF
--- a/internal/gen/dbmgr.go
+++ b/internal/gen/dbmgr.go
@@ -80,12 +80,7 @@ func SimpleCopyWithInsert(placeholder func(n int) string) func(ctx context.Conte
 			}
 			query = "INSERT INTO " + table + " VALUES (" + strings.Join(placeholders, ", ") + ")"
 		}
-		tx, err := db.BeginTx(ctx, nil)
-		if err != nil {
-			return 0, merry.Errorf("failed to begin transaction: %w", err)
-		}
-		fmt.Println(query)
-		stmt, err := tx.PrepareContext(ctx, query)
+		stmt, err := db.PrepareContext(ctx, query)
 		if err != nil {
 			return 0, merry.Errorf("failed to prepare insert query: %w", err)
 		}
@@ -125,10 +120,6 @@ func SimpleCopyWithInsert(placeholder func(n int) string) func(ctx context.Conte
 		}
 		// TODO if using batches, flush the last batch,
 		// TODO prepare another statement and count remaining rows
-		err = tx.Commit()
-		if err != nil {
-			return n, merry.Wrap(fmt.Errorf("failed to commit transaction: %w", err))
-		}
 		return n, merry.Wrap(rows.Err())
 	}
 }

--- a/internal/integrationtest/common.go
+++ b/internal/integrationtest/common.go
@@ -9,7 +9,6 @@ import (
 	"github.com/sclgo/usqlgen/pkg/fi"
 	"github.com/sclgo/usqlgen/pkg/sclerr"
 	"github.com/stretchr/testify/require"
-	"github.com/testcontainers/testcontainers-go"
 	"github.com/urfave/cli/v2"
 	"io"
 	"os"
@@ -17,12 +16,6 @@ import (
 	"strings"
 	"testing"
 )
-
-// Terminate terminates the given container. Useful in defer where
-// require.NoError(t, c.Terminate(ctx)) can't be used directly.
-func Terminate(ctx context.Context, t *testing.T, c testcontainers.Container) {
-	require.NoError(t, c.Terminate(ctx))
-}
 
 func IntegrationOnly(t *testing.T) {
 	if strings.ToLower(os.Getenv("SUITE")) != "integration" {

--- a/internal/integrationtest/common.go
+++ b/internal/integrationtest/common.go
@@ -58,7 +58,6 @@ func RunGeneratedUsql(t *testing.T, dsn string, command string, tmpDir string, t
 	require.NoError(t, err)
 
 	output := buf.String()
-	t.Log(output)
 	return output
 }
 

--- a/internal/integrationtest/databend/databend_test.go
+++ b/internal/integrationtest/databend/databend_test.go
@@ -12,8 +12,6 @@ import (
 	"github.com/testcontainers/testcontainers-go/wait"
 	"os"
 	"testing"
-
-	_ "github.com/datafuselabs/databend-go"
 )
 
 const Username = "databend"

--- a/internal/integrationtest/databend/databend_test.go
+++ b/internal/integrationtest/databend/databend_test.go
@@ -2,18 +2,15 @@ package databend_test
 
 import (
 	"context"
-	"encoding/csv"
 	"fmt"
 	"github.com/samber/lo"
 	"github.com/sclgo/usqlgen/internal/gen"
 	"github.com/sclgo/usqlgen/internal/integrationtest"
 	"github.com/sclgo/usqlgen/pkg/fi"
-	"github.com/sclgo/usqlgen/pkg/sclerr"
 	"github.com/stretchr/testify/require"
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/wait"
 	"os"
-	"path/filepath"
 	"testing"
 )
 
@@ -48,7 +45,7 @@ func TestDatabend(t *testing.T) {
 	ctx := context.Background()
 	c := fi.NoError(Setup(ctx)).Require(t)
 
-	defer integrationtest.Terminate(ctx, t, c)
+	defer fi.NoErrorF(fi.Bind(c.Terminate, ctx), t)
 	dsn := GetDsn(ctx, c)
 
 	inp := gen.Input{
@@ -60,10 +57,10 @@ func TestDatabend(t *testing.T) {
 	})
 
 	t.Run("copy", func(t *testing.T) {
-		t.Skip(`the following doesn't work because usql CopyWithInsert starts a transaction,
-but databend doesn't support multi-statement transactions. The databend driver (which appears
-to be a fork of clickhouse-go) issues a BEGIN statement on db.BeginTx even though the DB
-doesn't support it.`)
+		//		t.Skip(`the following doesn't work because usql CopyWithInsert starts a transaction,
+		//but databend doesn't support multi-statement transactions. The databend driver (which appears
+		//to be a fork of clickhouse-go) issues a BEGIN statement on db.BeginTx even though the DB
+		//doesn't support it.`)
 
 		tmpDir := integrationtest.MakeTempDir(t)
 		defer fi.NoErrorF(fi.Bind(os.RemoveAll, tmpDir), t)
@@ -72,19 +69,16 @@ doesn't support it.`)
 		err := inp.All()
 		require.NoError(t, err)
 
-		csvFile, err := os.Create(filepath.Join(tmpDir, "data.csv"))
-		require.NoError(t, err)
-		defer sclerr.CloseQuietly(csvFile)
-
-		csvWriter := csv.NewWriter(csvFile)
-		require.NoError(t, csvWriter.Write([]string{"hello", "world"}))
-		require.NoError(t, csvFile.Close())
-
 		output := integrationtest.RunGeneratedUsql(t, "databend:"+dsn, "create table dest(col1 string, col2 string);", tmpDir)
+		require.Contains(t, output, "CREATE TABLE")
+		output = integrationtest.RunGeneratedUsql(t, "csvq:.", `select "1", "2"`, tmpDir)
+		require.Contains(t, output, "(1 row)")
 
 		destExpression := "INSERT INTO dest VALUES (?, ?)"
-		copyCmd := fmt.Sprintf(`\copy csvq:. databend:%s 'select * from data' '%s'`, dsn, destExpression)
+		copyCmd := fmt.Sprintf(`\copy csvq:. databend:%s 'select string(1), string(2)' '%s'`, dsn, destExpression)
 		output = integrationtest.RunGeneratedUsql(t, "", copyCmd, tmpDir)
+		require.Contains(t, output, "COPY")
+		output = integrationtest.RunGeneratedUsql(t, "databend:"+dsn, "select * from dest", tmpDir)
 		require.Contains(t, output, "(1 row)")
 	})
 }

--- a/internal/integrationtest/impala/impala_test.go
+++ b/internal/integrationtest/impala/impala_test.go
@@ -18,8 +18,8 @@ func TestImpala(t *testing.T) {
 	integrationtest.IntegrationOnly(t)
 	ctx := context.Background()
 	c := fi.NoError(Setup(ctx)).Require(t)
+	defer fi.NoErrorF(fi.Bind(c.Terminate, ctx), t)
 
-	defer integrationtest.Terminate(ctx, t, c)
 	dsn := GetDsn(ctx, t, c)
 
 	t.Run("kprotoss driver", func(t *testing.T) {

--- a/internal/integrationtest/monetdb/monetdb_test.go
+++ b/internal/integrationtest/monetdb/monetdb_test.go
@@ -22,8 +22,8 @@ func TestMonetdb(t *testing.T) {
 	integrationtest.IntegrationOnly(t)
 	ctx := context.Background()
 	c := fi.NoError(Setup(ctx)).Require(t)
+	defer fi.NoErrorF(fi.Bind(c.Terminate, ctx), t)
 
-	defer integrationtest.Terminate(ctx, t, c)
 	dsn := GetDsn(ctx, c)
 	integrationtest.SanityPing(ctx, t, dsn, "monetdb")
 


### PR DESCRIPTION
databend supports prepared insert statements only in transactions,
which get converted to batches by driver. This works only in nightly build of container
used in tests.

Also some refactoring in integration tests.

Testing Done: databend int. test.