### PR TITLE
Add \copy unit test for when transactions aren't supported

### DIFF
--- a/internal/gen/dbmgr.go
+++ b/internal/gen/dbmgr.go
@@ -6,12 +6,13 @@ import (
 	"fmt"
 	"github.com/ansel1/merry/v2"
 	"github.com/samber/lo"
+	"github.com/sclgo/usqlgen/pkg/sclerr"
 	"github.com/xo/dburl"
 	"reflect"
 	"strings"
 )
 
-// This file is copied as in the generated usql wrapper.
+// This file is copied as is in the generated usql wrapper.
 // It must be self-contained. TODO move to dedicated package so self-containment can be enforced.
 
 // For now, we avoid depending on xo/usql, only on xo/dburl, to keep our dep tree small.
@@ -54,103 +55,111 @@ type DbWriter interface {
 	PrepareContext(ctx context.Context, query string) (*sql.Stmt, error)
 }
 
-// SimpleCopyWithInsert builds a copy handler based on insert.
-func SimpleCopyWithInsert(placeholder func(n int) string) func(ctx context.Context, db *sql.DB, rows *sql.Rows, table string) (int64, error) {
+type DB interface {
+	DbWriter
+	QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error)
+	BeginTx(ctx context.Context, opts *sql.TxOptions) (*sql.Tx, error)
+}
+
+// BuildSimpleCopy builds a copy handler based on insert.
+func BuildSimpleCopy(placeholder func(n int) string) func(ctx context.Context, db *sql.DB, rows *sql.Rows, table string) (int64, error) {
 	return func(ctx context.Context, db *sql.DB, rows *sql.Rows, table string) (int64, error) {
-		columns, err := rows.Columns()
-		if err != nil {
-			return 0, merry.Errorf("failed to fetch source rows columns: %w", err)
-		}
-		clen := len(columns)
-		query := table
-		if !strings.HasPrefix(strings.ToLower(query), "insert into") {
-			leftParen := strings.IndexRune(table, '(')
-			if leftParen == -1 {
-				colRows, err := db.QueryContext(ctx, "SELECT * FROM "+table+" WHERE 1=0")
-				if err != nil {
-					return 0, merry.Errorf("failed to execute query to determine target table columns: %w", err)
-				}
-				defer colRows.Close()
-				columns, err := colRows.Columns()
-				if err != nil {
-					return 0, merry.Errorf("failed to fetch target table columns: %w", err)
-				}
-				table += "(" + strings.Join(columns, ", ") + ")"
-			}
-			// TODO if the db supports multiple rows per insert, create batches of 100 rows
-			placeholders := make([]string, clen)
-			for i := 0; i < clen; i++ {
-				placeholders[i] = placeholder(i + 1)
-			}
-			query = "INSERT INTO " + table + " VALUES (" + strings.Join(placeholders, ", ") + ")"
-		}
-		var wrt DbWriter
-		wrt, err = db.BeginTx(ctx, nil)
-		if err != nil {
-			fmt.Printf("Failed to begin transaction. Falling back to non-transactional copy: %s\n", err)
-			wrt = db
-		}
-		stmt, err := wrt.PrepareContext(ctx, query)
-		if err != nil {
-			return 0, merry.Errorf("failed to prepare insert query: %w", err)
-		}
-		defer stmt.Close()
-		columnTypes, err := rows.ColumnTypes()
-		if err != nil {
-			return 0, merry.Errorf("failed to fetch source column types: %w", err)
-		}
-		values := make([]interface{}, clen)
-		valueRefs := make([]reflect.Value, clen)
-		actuals := make([]interface{}, clen)
-
-		for i := 0; i < len(columnTypes); i++ {
-			valueRefs[i] = reflect.New(columnTypes[i].ScanType())
-			values[i] = valueRefs[i].Interface()
-		}
-
-		rowsAffectedSucceeded := false
-		rowsAffectedSupported := true
-		var n int64
-		for rows.Next() {
-			err = rows.Scan(values...)
-			if err != nil {
-				return n, merry.Wrap(fmt.Errorf("failed to scan row: %w", err))
-			}
-
-			for i := range values {
-				actuals[i] = valueRefs[i].Elem().Interface()
-			}
-			res, err := stmt.ExecContext(ctx, actuals...)
-			if err != nil {
-				return n, merry.Wrap(fmt.Errorf("failed to exec insert: %w", err))
-			}
-
-			var rn int64
-			if rowsAffectedSupported {
-				rn, err = res.RowsAffected()
-			}
-			if err != nil {
-				if rowsAffectedSucceeded {
-					return n, merry.Wrap(fmt.Errorf("failed to check rows affected: %w", err))
-				} else {
-					fmt.Printf("Failed to retrieve rowsAffected. Assuming not supported by driver: %s\n", err)
-					rowsAffectedSupported = false
-					rn = 0
-				}
-			} else {
-				rowsAffectedSucceeded = true
-			}
-			n += rn
-		}
-		// TODO if using batches, flush the last batch,
-		// TODO prepare another statement and count remaining rows
-		if tx, ok := wrt.(*sql.Tx); ok {
-			err = tx.Commit()
-		}
-
-		if err != nil {
-			return n, merry.Wrap(fmt.Errorf("failed to commit transaction: %w", err))
-		}
-		return n, merry.Wrap(rows.Err())
+		return SimpleCopyWithInsert(ctx, db, rows, table, placeholder)
 	}
+}
+
+func SimpleCopyWithInsert(ctx context.Context, db DB, rows *sql.Rows, table string, placeholder func(n int) string) (int64, error) {
+	columns, err := rows.Columns()
+	if err != nil {
+		return 0, merry.Errorf("failed to fetch source rows columns: %w", err)
+	}
+	clen := len(columns)
+	query := table
+	if !strings.HasPrefix(strings.ToLower(query), "insert into") {
+		leftParen := strings.IndexRune(table, '(')
+		if leftParen == -1 {
+			colRows, err := db.QueryContext(ctx, "SELECT * FROM "+table+" WHERE 1=0")
+			if err != nil {
+				return 0, merry.Errorf("failed to execute query to determine target table columns: %w", err)
+			}
+			defer sclerr.CloseQuietly(colRows)
+			columns, err := colRows.Columns()
+			if err != nil {
+				return 0, merry.Errorf("failed to fetch target table columns: %w", err)
+			}
+			table += "(" + strings.Join(columns, ", ") + ")"
+		}
+		placeholders := make([]string, clen)
+		for i := 0; i < clen; i++ {
+			placeholders[i] = placeholder(i + 1)
+		}
+		query = "INSERT INTO " + table + " VALUES (" + strings.Join(placeholders, ", ") + ")"
+	}
+	var wrt DbWriter
+	wrt, err = db.BeginTx(ctx, nil)
+	if err != nil {
+		fmt.Printf("Failed to begin transaction. Falling back to non-transactional copy: %s\n", err)
+		wrt = db
+	}
+	stmt, err := wrt.PrepareContext(ctx, query)
+	if err != nil {
+		return 0, merry.Errorf("failed to prepare insert query: %w", err)
+	}
+	defer sclerr.CloseQuietly(stmt)
+	columnTypes, err := rows.ColumnTypes()
+	if err != nil {
+		return 0, merry.Errorf("failed to fetch source column types: %w", err)
+	}
+	values := make([]interface{}, clen)
+	valueRefs := make([]reflect.Value, clen)
+	actuals := make([]interface{}, clen)
+
+	for i := 0; i < len(columnTypes); i++ {
+		valueRefs[i] = reflect.New(columnTypes[i].ScanType())
+		values[i] = valueRefs[i].Interface()
+	}
+
+	rowsAffectedSucceeded := false
+	rowsAffectedSupported := true
+	var n int64
+	for rows.Next() {
+		err = rows.Scan(values...)
+		if err != nil {
+			return n, merry.Wrap(fmt.Errorf("failed to scan row: %w", err))
+		}
+
+		for i := range values {
+			actuals[i] = valueRefs[i].Elem().Interface()
+		}
+		res, err := stmt.ExecContext(ctx, actuals...)
+		if err != nil {
+			return n, merry.Wrap(fmt.Errorf("failed to exec insert: %w", err))
+		}
+
+		var rn int64
+		if rowsAffectedSupported {
+			rn, err = res.RowsAffected()
+		}
+		if err != nil {
+			if rowsAffectedSucceeded {
+				return n, merry.Wrap(fmt.Errorf("failed to check rows affected: %w", err))
+			} else {
+				fmt.Printf("Failed to retrieve rowsAffected. Assuming not supported by driver: %s\n", err)
+				rowsAffectedSupported = false
+				rn = 0
+			}
+		} else {
+			rowsAffectedSucceeded = true
+		}
+		n += rn
+	}
+
+	if tx, ok := wrt.(*sql.Tx); ok {
+		err = tx.Commit()
+	}
+
+	if err != nil {
+		return n, merry.Wrap(fmt.Errorf("failed to commit transaction: %w", err))
+	}
+	return n, merry.Wrap(rows.Err())
 }

--- a/internal/gen/dbmgr_test.go
+++ b/internal/gen/dbmgr_test.go
@@ -3,6 +3,7 @@ package gen_test
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"github.com/sclgo/usqlgen/internal/gen"
 	"github.com/sclgo/usqlgen/pkg/sclerr"
@@ -29,27 +30,36 @@ var sqliteRandomDataQuery = fmt.Sprintf(`
 SELECT x,y FROM cte;
 `, sqliteNumInputRows)
 
+type copyTestSpec struct {
+	driver          string
+	dsn             string
+	randomDataQuery string
+	numInputRows    int
+	expectedType    reflect.Type
+}
+
+var sqliteSourceSpec = copyTestSpec{
+	driver:          "sqlite",
+	dsn:             ":memory:",
+	randomDataQuery: sqliteRandomDataQuery,
+	numInputRows:    sqliteNumInputRows,
+	expectedType:    reflect.TypeFor[int64](),
+}
+
+var csvqSourceSpec = copyTestSpec{
+	driver:          "csvq",
+	dsn:             ".",
+	randomDataQuery: `select 1, "hello" union all select 2, "world"`,
+	numInputRows:    2,
+	expectedType:    reflect.TypeFor[any](),
+}
+
 func TestRegisterNewDrivers(t *testing.T) {
 	newDrivers := gen.RegisterNewDrivers(sql.Drivers())
 	require.Empty(t, newDrivers)
 }
 
 func TestSimpleCopyWithInsert_SqliteDest(t *testing.T) {
-	sqliteSourceSpec := copyTestSpec{
-		driver:          "sqlite",
-		dsn:             ":memory:",
-		randomDataQuery: sqliteRandomDataQuery,
-		numInputRows:    sqliteNumInputRows,
-		expectedType:    reflect.TypeFor[int64](),
-	}
-	csvqSourceSpec := copyTestSpec{
-		driver:          "csvq",
-		dsn:             ".",
-		randomDataQuery: `select 1, "hello" union all select 2, "world"`,
-		numInputRows:    2,
-		expectedType:    reflect.TypeFor[any](),
-	}
-
 	for _, spec := range []copyTestSpec{sqliteSourceSpec, csvqSourceSpec} {
 		t.Run(spec.driver, func(t *testing.T) {
 			runCopyTests(t, spec)
@@ -62,27 +72,14 @@ func runCopyTests(t *testing.T, spec copyTestSpec) {
 	require.NoError(t, err)
 	defer sclerr.CloseQuietly(sourceDb)
 
-	copyFunc := gen.SimpleCopyWithInsert(gen.FixedPlaceholder("?"))
-
-	db, err := sql.Open("sqlite", "file::memory:?cache=shared")
-	require.NoError(t, err)
-	defer sclerr.CloseQuietly(db)
+	copyFunc := gen.BuildSimpleCopy(gen.FixedPlaceholder("?"))
 
 	ctx := context.Background()
-
-	_, err = db.ExecContext(ctx, "create table hello(a integer, b varchar)")
-	require.NoError(t, err)
-
-	defer func() {
-		_, err := db.ExecContext(ctx, "drop table hello")
-		require.NoError(t, err)
-	}()
-
-	randomDataQuery := spec.randomDataQuery
-	numInputRows := spec.numInputRows
+	db, cleanup := prepareTargetDb(t)
+	defer cleanup()
 
 	t.Run("scantype is expected", func(t *testing.T) {
-		someRows, err := sourceDb.QueryContext(ctx, randomDataQuery)
+		someRows, err := sourceDb.QueryContext(ctx, spec.randomDataQuery)
 		require.NoError(t, err)
 		defer sclerr.CloseQuietly(someRows)
 
@@ -93,41 +90,54 @@ func runCopyTests(t *testing.T, spec copyTestSpec) {
 
 	t.Run("copy to table with name only", func(t *testing.T) {
 
-		someRows, err := sourceDb.QueryContext(ctx, randomDataQuery)
+		someRows, err := sourceDb.QueryContext(ctx, spec.randomDataQuery)
 		require.NoError(t, err)
 		defer sclerr.CloseQuietly(someRows)
 
 		rowsAdded, err := copyFunc(ctx, db, someRows, "hello")
 		require.NoError(t, err)
 
-		require.EqualValues(t, numInputRows, rowsAdded)
+		require.EqualValues(t, spec.numInputRows, rowsAdded)
 
 		checkHelloColumn(t, db)
 	})
 
 	t.Run("copy to table with name and columns", func(t *testing.T) {
-		someRows, err := sourceDb.QueryContext(ctx, randomDataQuery)
+		someRows, err := sourceDb.QueryContext(ctx, spec.randomDataQuery)
 		require.NoError(t, err)
 		defer sclerr.CloseQuietly(someRows)
 
 		rowsAdded, err := copyFunc(ctx, db, someRows, "hello(a, b)")
 		require.NoError(t, err)
 
-		require.EqualValues(t, numInputRows, rowsAdded)
+		require.EqualValues(t, spec.numInputRows, rowsAdded)
 		checkHelloColumn(t, db)
 	})
 
 	t.Run("copy to table with insert", func(t *testing.T) {
-		someRows, err := sourceDb.QueryContext(ctx, randomDataQuery)
+		someRows, err := sourceDb.QueryContext(ctx, spec.randomDataQuery)
 		require.NoError(t, err)
 		defer sclerr.CloseQuietly(someRows)
 
 		rowsAdded, err := copyFunc(ctx, db, someRows, "insert into hello(a, b) values (?, ?)")
 		require.NoError(t, err)
 
-		require.EqualValues(t, numInputRows, rowsAdded)
+		require.EqualValues(t, spec.numInputRows, rowsAdded)
 		checkHelloColumn(t, db)
 	})
+}
+
+func prepareTargetDb(t *testing.T) (*sql.DB, func()) {
+	db, err := sql.Open("sqlite", "file::memory:?cache=shared")
+	require.NoError(t, err)
+
+	_, err = db.Exec("create table hello(a integer, b varchar)")
+	require.NoError(t, err)
+	return db, func() {
+		_, err := db.Exec("drop table if exists hello")
+		require.NoError(t, err)
+		sclerr.CloseQuietly(db)
+	}
 }
 
 func checkHelloColumn(t *testing.T, db *sql.DB) {
@@ -137,10 +147,47 @@ func checkHelloColumn(t *testing.T, db *sql.DB) {
 	require.Equal(t, "hello", bColumn)
 }
 
-type copyTestSpec struct {
-	driver          string
-	dsn             string
-	randomDataQuery string
-	numInputRows    int
-	expectedType    reflect.Type
+func TestSimpleCopyWithInsert_EdgeCases(t *testing.T) {
+	spec := csvqSourceSpec
+	sourceDb, err := sql.Open(spec.driver, spec.dsn)
+	require.NoError(t, err)
+	defer sclerr.CloseQuietly(sourceDb)
+
+	targetDb, cleanup := prepareTargetDb(t)
+	defer cleanup()
+
+	db := testDb{
+		DB:                targetDb,
+		blockTransactions: true,
+	}
+
+	ctx := context.Background()
+
+	someRows, err := sourceDb.QueryContext(ctx, spec.randomDataQuery)
+	require.NoError(t, err)
+	defer sclerr.CloseQuietly(someRows)
+
+	rowsAdded, err := gen.SimpleCopyWithInsert(
+		ctx,
+		db,
+		someRows,
+		"insert into hello(a, b) values (?, ?)",
+		gen.FixedPlaceholder("?"))
+	require.NoError(t, err)
+
+	require.EqualValues(t, spec.numInputRows, rowsAdded)
+	checkHelloColumn(t, targetDb)
+}
+
+type testDb struct {
+	*sql.DB
+
+	blockTransactions bool
+}
+
+func (d testDb) BeginTx(ctx context.Context, opts *sql.TxOptions) (*sql.Tx, error) {
+	if d.blockTransactions {
+		return nil, errors.New("transactions are not supported")
+	}
+	return d.DB.BeginTx(ctx, opts)
 }

--- a/internal/gen/main.go.tpl
+++ b/internal/gen/main.go.tpl
@@ -21,7 +21,7 @@ func main() {
 	newDrivers := gen.RegisterNewDrivers(lo.Keys(drivers.Available()))
 	for _, driver := range newDrivers {
 		drivers.Register(driver, drivers.Driver{
-		    Copy: gen.SimpleCopyWithInsert(gen.FixedPlaceholder("?")),
+		    Copy: gen.BuildSimpleCopy(gen.FixedPlaceholder("?")),
 		})
 	}
 {{end}}


### PR DESCRIPTION
Add \copy unit test for when transactions aren't supported. Refactored SimpleCopyWithInsert to
support providing a DB interface.

Testing Done: go test ./...