### PR TITLE
Allow configuring usql version

### DIFF
--- a/internal/gen/filetools.go
+++ b/internal/gen/filetools.go
@@ -1,0 +1,23 @@
+package gen
+
+import (
+	"github.com/ansel1/merry/v2"
+	"io/fs"
+	"os"
+	"path/filepath"
+)
+
+func chmod(path string) error {
+	return merry.Wrap(filepath.WalkDir(path, chmodHandler))
+}
+
+//nolint:unused seems to be a bug in staticheck U1000 but couldn't reproduce in a minimal example
+func chmodHandler(path string, d fs.DirEntry, err error) error {
+	if err != nil {
+		return err
+	}
+	if !d.IsDir() {
+		return os.Chmod(path, fileMode)
+	}
+	return nil
+}

--- a/internal/gen/gen_test.go
+++ b/internal/gen/gen_test.go
@@ -73,7 +73,8 @@ func runGenAll(t *testing.T, inp gen.Input) string {
 func TestInput_AllDownload(t *testing.T) {
 	fi.SkipLongTest(t)
 	inp := gen.Input{
-		Imports: []string{"github.com/MonetDB/MonetDB-Go/v2"},
+		Imports:     []string{"github.com/MonetDB/MonetDB-Go/v2"},
+		USQLVersion: "master",
 	}
 	var err error
 	tmpDir := t.TempDir()

--- a/internal/shell/compile.go
+++ b/internal/shell/compile.go
@@ -12,8 +12,10 @@ import (
 type CompileCommand struct {
 	CommandBase
 
-	Imports  cli.StringSlice
-	Replaces cli.StringSlice
+	Imports     cli.StringSlice
+	Replaces    cli.StringSlice
+	USQLModule  string
+	USQLVersion string
 }
 
 func (c *CompileCommand) compile(compileCmd string, compileArgs ...string) error {
@@ -30,9 +32,11 @@ func (c *CompileCommand) compile(compileCmd string, compileArgs ...string) error
 		return merry.Wrap(err)
 	}
 	genInput := gen.Input{
-		Imports:    c.Imports.Value(),
-		Replaces:   c.Replaces.Value(),
-		WorkingDir: workingDir,
+		Imports:     c.Imports.Value(),
+		Replaces:    c.Replaces.Value(),
+		WorkingDir:  workingDir,
+		USQLVersion: c.USQLVersion,
+		USQLModule:  c.USQLModule,
 	}
 	err = genInput.All()
 	if err != nil {
@@ -63,6 +67,19 @@ func (c *CompileCommand) MakeFlags() []cli.Flag {
 			Usage:       "adds a replace directive to the generated module with the same format as 'go mod edit -replace', can be repeated",
 			Aliases:     []string{"r"},
 			Destination: &c.Replaces,
+		},
+		&cli.StringFlag{
+			Name:        "usql-module",
+			Usage:       "module name of usql fork to use if needed",
+			Value:       "github.com/xo/usql",
+			Destination: &c.USQLModule,
+		},
+		&cli.StringFlag{
+			Name:        "usql-version",
+			Usage:       "usql version to use; can be any valid module version incl. 'latest', release, tag, branch, or Git commit",
+			Aliases:     []string{"uv"},
+			Value:       "latest",
+			Destination: &c.USQLVersion,
 		},
 	}, c.CommandBase.MakeFlags()...)
 }

--- a/pkg/lang/lang.go
+++ b/pkg/lang/lang.go
@@ -1,0 +1,8 @@
+package lang
+
+import "github.com/samber/lo"
+
+func IfEmpty[T comparable](value, alt T) T {
+	result, _ := lo.Coalesce(value, alt)
+	return result
+}


### PR DESCRIPTION
Allows configuring base usql version using the usql-version and usql-module parameters.

Simplifies slightly generation code.

Testing Done: make test test