### PR TITLE
Batching support for \copy

### DIFF
--- a/internal/gen/dbmgr.go
+++ b/internal/gen/dbmgr.go
@@ -140,7 +140,7 @@ func SimpleCopyWithInsert(ctx context.Context, db DB, rows *sql.Rows, table stri
 			return n, err
 		}
 		n += rn
-		actuals = actuals[:0]
+		actuals = actuals[:0] // truncate but keep underlying array size
 	}
 
 	if len(actuals) > 0 {
@@ -171,7 +171,6 @@ func writeActuals(ctx context.Context, stmt *sql.Stmt, actuals []interface{}, ro
 	if err != nil {
 		return 0, merry.Wrap(fmt.Errorf("failed to exec insert: %w", err))
 	}
-	actuals = actuals[:0] // truncate but keep underlying array size
 
 	var rn int64
 	if *rowsAffectedSupported {

--- a/internal/gen/dbmgr.go
+++ b/internal/gen/dbmgr.go
@@ -64,11 +64,11 @@ type DB interface {
 // BuildSimpleCopy builds a copy handler based on insert.
 func BuildSimpleCopy(placeholder func(n int) string) func(ctx context.Context, db *sql.DB, rows *sql.Rows, table string) (int64, error) {
 	return func(ctx context.Context, db *sql.DB, rows *sql.Rows, table string) (int64, error) {
-		return SimpleCopyWithInsert(ctx, db, rows, table, placeholder)
+		return SimpleCopyWithInsert(ctx, db, rows, table, 10, placeholder)
 	}
 }
 
-func SimpleCopyWithInsert(ctx context.Context, db DB, rows *sql.Rows, table string, placeholder func(n int) string) (int64, error) {
+func SimpleCopyWithInsert(ctx context.Context, db DB, rows *sql.Rows, table string, batchSize int, placeholder func(n int) string) (int64, error) {
 	columns, err := rows.Columns()
 	if err != nil {
 		return 0, merry.Errorf("failed to fetch source rows columns: %w", err)
@@ -90,11 +90,9 @@ func SimpleCopyWithInsert(ctx context.Context, db DB, rows *sql.Rows, table stri
 			}
 			table += "(" + strings.Join(columns, ", ") + ")"
 		}
-		placeholders := make([]string, clen)
-		for i := 0; i < clen; i++ {
-			placeholders[i] = placeholder(i + 1)
-		}
-		query = "INSERT INTO " + table + " VALUES (" + strings.Join(placeholders, ", ") + ")"
+		query = makeQuery(clen, batchSize, table, placeholder)
+	} else {
+		batchSize = 1 // no batching
 	}
 	var wrt DbWriter
 	wrt, err = db.BeginTx(ctx, nil)
@@ -113,16 +111,16 @@ func SimpleCopyWithInsert(ctx context.Context, db DB, rows *sql.Rows, table stri
 	}
 	values := make([]interface{}, clen)
 	valueRefs := make([]reflect.Value, clen)
-	actuals := make([]interface{}, clen)
+	actuals := make([]interface{}, 0, clen*batchSize)
 
 	for i := 0; i < len(columnTypes); i++ {
 		valueRefs[i] = reflect.New(columnTypes[i].ScanType())
 		values[i] = valueRefs[i].Interface()
 	}
 
-	rowsAffectedSucceeded := false
 	rowsAffectedSupported := true
 	var n int64
+
 	for rows.Next() {
 		err = rows.Scan(values...)
 		if err != nil {
@@ -130,27 +128,30 @@ func SimpleCopyWithInsert(ctx context.Context, db DB, rows *sql.Rows, table stri
 		}
 
 		for i := range values {
-			actuals[i] = valueRefs[i].Elem().Interface()
-		}
-		res, err := stmt.ExecContext(ctx, actuals...)
-		if err != nil {
-			return n, merry.Wrap(fmt.Errorf("failed to exec insert: %w", err))
+			actuals = append(actuals, valueRefs[i].Elem().Interface())
 		}
 
-		var rn int64
-		if rowsAffectedSupported {
-			rn, err = res.RowsAffected()
+		if len(actuals) < batchSize*clen {
+			continue
 		}
+
+		rn, err := writeActuals(ctx, stmt, actuals, &rowsAffectedSupported)
 		if err != nil {
-			if rowsAffectedSucceeded {
-				return n, merry.Wrap(fmt.Errorf("failed to check rows affected: %w", err))
-			} else {
-				fmt.Printf("Failed to retrieve rowsAffected. Assuming not supported by driver: %s\n", err)
-				rowsAffectedSupported = false
-				rn = 0
-			}
-		} else {
-			rowsAffectedSucceeded = true
+			return n, err
+		}
+		n += rn
+		actuals = actuals[:0]
+	}
+
+	if len(actuals) > 0 {
+		finStmt, err := wrt.PrepareContext(ctx, makeQuery(clen, len(actuals)/clen, table, placeholder))
+		if err != nil {
+			return 0, merry.Errorf("failed to prepare insert query: %w", err)
+		}
+		defer finStmt.Close()
+		rn, err := writeActuals(ctx, finStmt, actuals, &rowsAffectedSupported)
+		if err != nil {
+			return n, err
 		}
 		n += rn
 	}
@@ -163,4 +164,40 @@ func SimpleCopyWithInsert(ctx context.Context, db DB, rows *sql.Rows, table stri
 		return n, merry.Wrap(fmt.Errorf("failed to commit transaction: %w", err))
 	}
 	return n, merry.Wrap(rows.Err())
+}
+
+func writeActuals(ctx context.Context, stmt *sql.Stmt, actuals []interface{}, rowsAffectedSupported *bool) (int64, error) {
+	res, err := stmt.ExecContext(ctx, actuals...)
+	if err != nil {
+		return 0, merry.Wrap(fmt.Errorf("failed to exec insert: %w", err))
+	}
+	actuals = actuals[:0] // truncate but keep underlying array size
+
+	var rn int64
+	if *rowsAffectedSupported {
+		rn, err = res.RowsAffected()
+	}
+	if err != nil {
+		if *rowsAffectedSupported {
+			fmt.Printf("Failed to retrieve rowsAffected. Assuming not supported by driver: %s\n", err)
+			*rowsAffectedSupported = false
+			rn = 0
+		}
+	}
+	return rn, nil
+}
+
+func makeQuery(clen int, rows int, tableSpec string, placeholder func(n int) string) string {
+	query := "INSERT INTO " + tableSpec + " VALUES "
+	placeholders := make([]string, clen)
+	for i := 0; i < rows; i++ {
+		for j := 0; j < clen; j++ {
+			placeholders[j] = placeholder(i*clen + j + 1)
+		}
+		query += "(" + strings.Join(placeholders, ", ") + ")"
+		if i < rows-1 {
+			query += ", "
+		}
+	}
+	return query
 }

--- a/internal/gen/dbmgr_test.go
+++ b/internal/gen/dbmgr_test.go
@@ -172,6 +172,7 @@ func TestSimpleCopyWithInsert_EdgeCases(t *testing.T) {
 		db,
 		someRows,
 		"insert into hello(a, b) values (?, ?)",
+		1,
 		gen.FixedPlaceholder("?"))
 	require.NoError(t, err)
 


### PR DESCRIPTION
The copy implementation for new drivers now batches writes.
The handling of errors reported by RowsAffected is also simplified
and less strict as a result.

Testing Done: make test itest