### PR TITLE
Populate proper version in output of usql --version

### DIFF
--- a/internal/gen/gen_test.go
+++ b/internal/gen/gen_test.go
@@ -2,14 +2,15 @@ package gen_test
 
 import (
 	"bytes"
-	"github.com/samber/lo"
-	"github.com/sclgo/usqlgen/internal/gen"
-	"github.com/sclgo/usqlgen/pkg/fi"
-	"github.com/stretchr/testify/require"
 	"io"
 	"os"
 	"os/exec"
 	"testing"
+
+	"github.com/samber/lo"
+	"github.com/sclgo/usqlgen/internal/gen"
+	"github.com/sclgo/usqlgen/pkg/fi"
+	"github.com/stretchr/testify/require"
 )
 
 func TestInput_Main(t *testing.T) {
@@ -92,16 +93,18 @@ func TestInput_AllDownload(t *testing.T) {
 	fi.SkipLongTest(t)
 	inp := gen.Input{
 		Imports:     []string{"github.com/MonetDB/MonetDB-Go/v2"},
-		USQLVersion: "master",
+		USQLVersion: "v0.19.14",
 	}
 	var err error
 	tmpDir := t.TempDir()
 	inp.WorkingDir = tmpDir
-	err = inp.AllDownload()
+	result, err := inp.AllDownload()
 	require.NoError(t, err)
 	entries, err := os.ReadDir(tmpDir)
 	require.NoError(t, err)
 	require.True(t, lo.ContainsBy(entries, func(item os.DirEntry) bool {
 		return item.Name() == "main.go"
 	}))
+
+	require.Equal(t, inp.USQLVersion, result.DownloadedUsqlVersion)
 }

--- a/internal/integrationtest/build_test.go
+++ b/internal/integrationtest/build_test.go
@@ -1,0 +1,48 @@
+package integrationtest
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/sclgo/usqlgen/internal/shell"
+	"github.com/sclgo/usqlgen/pkg/fi"
+	"github.com/stretchr/testify/require"
+)
+
+// Tests of the overall build process
+
+// TestVersion is an integration test --version in the produced binary
+// This test complements the unit test in shell/cmd_build_test.go. The unit test
+// validates only if the version is injected in the build process but only this
+// test confirms that usql will use it.
+func TestVersion(t *testing.T) {
+	IntegrationOnly(t)
+
+	tmpDir := t.TempDir()
+	currentWorkDir := fi.NoError(os.Getwd()).Require(t)
+	defer fi.NoErrorF(fi.Bind(os.Chdir, currentWorkDir), t)
+	require.NoError(t, os.Chdir(tmpDir))
+
+	cmds := shell.NewCommands(nil)
+	cmds.BuildCmd.USQLModule = "github.com/xo/usql"
+	testVersion := "v0.19.14"
+	cmds.BuildCmd.USQLVersion = testVersion
+	cmds.BuildCmd.Globals.PassthroughArgs = []string{"-tags", "no_base"}
+
+	err := cmds.BuildCmd.Action(nil)
+	require.NoError(t, err)
+
+	cmd := exec.Command("./usql", "--version")
+	cmd.Dir = tmpDir
+	var buf bytes.Buffer
+	cmd.Stdout = io.MultiWriter(&buf, os.Stdout)
+	cmd.Stderr = os.Stderr
+	require.NoError(t, cmd.Run())
+
+	require.Equal(t, fmt.Sprintf("usql %s-usqlgen", testVersion), strings.TrimSpace(buf.String()))
+}

--- a/internal/shell/cmd_build.go
+++ b/internal/shell/cmd_build.go
@@ -37,16 +37,13 @@ func (c *BuildCommand) Action(stdout io.Writer) error {
 
 	destination := c.output
 	if destination == "" {
-		var err error
-		destination, err = os.Getwd()
-		if err != nil {
-			return merry.Wrap(err)
-		}
+		destination = "." // will replaced by absolute path below
 	}
 
 	if c.output == "-" {
 		// NB: Find a way to avoid creating another temp file
-		destination, err := touchTempFile()
+		var err error
+		destination, err = touchTempFile()
 		if err != nil {
 			return err
 		}

--- a/internal/shell/cmd_compile_test.go
+++ b/internal/shell/cmd_compile_test.go
@@ -1,9 +1,10 @@
 package shell
 
 import (
+	"testing"
+
 	"github.com/sclgo/usqlgen/internal/gen"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 func TestCompile(t *testing.T) {
@@ -11,9 +12,9 @@ func TestCompile(t *testing.T) {
 	t.Run("create tmp dir", func(t *testing.T) {
 		cmd := CompileCommand{
 			CommandBase: Base(new(GlobalParams)),
-			generator: func(input gen.Input) error {
+			generator: func(input gen.Input) (gen.Result, error) {
 				require.DirExists(t, input.WorkingDir)
-				return nil
+				return gen.Result{}, nil
 			},
 			goBin: "echo",
 		}


### PR DESCRIPTION
We populate the actual usql version used, also indicating it that it was modified by usqlgen.

Testing done: manual: go run . build && ./usql --version; also new unit and integration tests