### PR TITLE
Shorter prompt for custom databases

### DIFF
--- a/internal/gen/main.go.tpl
+++ b/internal/gen/main.go.tpl
@@ -6,6 +6,7 @@ import (
 	"slices"
 	"github.com/xo/usql/gen"
 	"github.com/xo/usql/drivers"
+	"github.com/xo/usql/env"
 )
 {{end}}
 
@@ -21,6 +22,8 @@ func main() {
 		    Copy: gen.BuildSimpleCopy(gen.FixedPlaceholder("?")),
 		})
 	}
+	// The default prompt is sometimes too long for DBs with opaque URLs
+	env.Set("PROMPT1", "%S%N%m%R%# ")
 {{end}}
 	origMain()
 }


### PR DESCRIPTION
Default prompt is too long for DBs with opaque URL because the `%/` element includes the entire opaque part of the URL.
When a new DB is imported, remove %/ from the default prompt.

`\set PROMPT1` or `--set` should continue to work normally. 