### PR TITLE
feat: strip trailing semicolons by default; add option to include them

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ You can try the same with databases or data engines like
 
 `usqlgen` also allows you to use alternative drivers of supported databases. Examples include:
 
+- [github.com/microsoft/gocosmos](https://github.com/microsoft/gocosmos) - an official copy/fork of the unofficial driver included in `usql`
 - [github.com/sclgo/impala-go](https://github.com/sclgo/impala-go) - modernized variant of the built-in [Apache Impala](https://impala.apache.org/) driver
 - [github.com/mailru/go-clickhouse/v2](https://github.com/mailru/go-clickhouse) - HTTP-only alternative of the built-in Clickhouse driver
 - [github.com/sclgo/duckdb-adbc-go](https://github.com/sclgo/duckdb-adbc-go) - alternative driver for DuckDB that uses [its ADBC C API](https://duckdb.org/docs/clients/adbc)

--- a/internal/gen/dbmgr.go
+++ b/internal/gen/dbmgr.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/url"
 	"reflect"
+	"regexp"
 	"slices"
 	"strings"
 
@@ -19,6 +20,8 @@ import (
 // For now, we also avoid depending on xo/usql, only on xo/dburl, to keep our dep tree small.
 // This may change in the future.
 // Avoid depending on libraries, not already used in usql.
+
+var SemicolonEndRE = regexp.MustCompile(`;?\s*$`)
 
 func FindNew(current []string, original []string) []string {
 	return slices.DeleteFunc(current, func(s string) bool {

--- a/internal/gen/gen.go
+++ b/internal/gen/gen.go
@@ -34,6 +34,8 @@ type Input struct {
 	WorkingDir  string
 	USQLModule  string
 	USQLVersion string
+
+	IncludeSemicolon bool
 }
 
 type Result struct {

--- a/internal/integrationtest/cosmos/cosmos_test.go
+++ b/internal/integrationtest/cosmos/cosmos_test.go
@@ -1,0 +1,43 @@
+package cosmos
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"os/exec"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/sclgo/usqlgen/internal/gen"
+	"github.com/sclgo/usqlgen/internal/integrationtest"
+	"github.com/sclgo/usqlgen/pkg/fi"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCosmos(t *testing.T) {
+	fi.SkipLongTest(t)
+
+	inp := gen.Input{
+		Imports: []string{"github.com/microsoft/gocosmos"},
+	}
+
+	tmpDir := t.TempDir()
+	inp.WorkingDir = tmpDir
+
+	err := inp.All()
+	require.NoError(t, err)
+
+	cmd := exec.Command("go", "run", "-tags", integrationtest.NoBaseTag, ".", "gocosmos:AccountEndpoint=https://localhost;AccountKey=test", "-c", `LIST DATABASES;`)
+	cmd.Dir = tmpDir
+	var buf bytes.Buffer
+	cmd.Stdout = io.Discard
+	cmd.Stderr = io.MultiWriter(&buf, os.Stderr)
+	cmd.Env = slices.DeleteFunc(os.Environ(), func(s string) bool {
+		return strings.HasPrefix(s, "GO")
+	})
+	err = cmd.Run()
+	output := buf.String()
+	require.ErrorContains(t, err, "exit status 1")
+	require.Contains(t, output, `Get "https://localhost/dbs"`)
+}

--- a/internal/integrationtest/databend/databend_test.go
+++ b/internal/integrationtest/databend/databend_test.go
@@ -72,7 +72,7 @@ func TestDatabend(t *testing.T) {
 
 		destExpression := "INSERT INTO dest VALUES (?, ?)"
 		copyCmd := fmt.Sprintf(`\copy csvq:. databend:%s 'select string(1), string(2)' '%s'`, dsn, destExpression)
-		output = integrationtest.RunGeneratedUsql(t, "", copyCmd, tmpDir)
+		output = integrationtest.RunGeneratedUsql(t, "", copyCmd, tmpDir, "csvq")
 		require.Contains(t, output, "COPY")
 		output = integrationtest.RunGeneratedUsql(t, "databend:"+dsn, "select * from dest", tmpDir)
 		require.Contains(t, output, "(1 row)")

--- a/internal/integrationtest/impala/impala_test.go
+++ b/internal/integrationtest/impala/impala_test.go
@@ -72,7 +72,7 @@ func TestImpala(t *testing.T) {
 
 			destExpression := "INSERT INTO dest VALUES (?, ?)"
 			copyCmd := fmt.Sprintf(`\copy csvq:. impala:%s 'select string(1), string(2)' '%s'`, dsn, destExpression)
-			output = integrationtest.RunGeneratedUsql(t, "", copyCmd, tmpDir)
+			output = integrationtest.RunGeneratedUsql(t, "", copyCmd, tmpDir, "csvq")
 			require.Contains(t, output, "COPY")
 
 			output = integrationtest.RunGeneratedUsql(t, "impala:"+dsn, "select * from dest", tmpDir)

--- a/internal/shell/cmd_compile.go
+++ b/internal/shell/cmd_compile.go
@@ -21,6 +21,7 @@ type CompileCommand struct {
 	Gets        cli.StringSlice
 	USQLModule  string
 	USQLVersion string
+	DbOptions   cli.StringSlice
 }
 
 func (c *CompileCommand) compile(compileCmd string, compileArgs ...string) error {
@@ -64,6 +65,10 @@ func (c *CompileCommand) generate(workingDir string) (gen.Result, error) {
 		USQLVersion: c.USQLVersion,
 		USQLModule:  c.USQLModule,
 	}
+	err := applyOptionsFromNames(c.DbOptions.Value(), &genInput)
+	if err != nil {
+		return gen.Result{}, err
+	}
 	return c.generator(genInput)
 }
 
@@ -98,6 +103,11 @@ func (c *CompileCommand) MakeFlags() []cli.Flag {
 			Aliases:     []string{"uv"},
 			Value:       "latest",
 			Destination: &c.USQLVersion,
+		},
+		&cli.StringSliceFlag{
+			Name:        "db-option",
+			Usage:       `option that modifies configuration for newly imported drivers; use "usqlgen list options" to see what options are available`,
+			Destination: &c.DbOptions,
 		},
 	}, c.CommandBase.MakeFlags()...)
 }

--- a/internal/shell/commands.go
+++ b/internal/shell/commands.go
@@ -26,9 +26,8 @@ type GenerateCommand struct {
 func (c *GenerateCommand) MakeFlags() []cli.Flag {
 	return append(c.CompileCommand.MakeFlags(),
 		&cli.StringFlag{
-			Name: "output",
-			Usage: `path to directory where the generated code will be written; 
-if value is -, tar archive will be written to standard output`,
+			Name:        "output",
+			Usage:       `path to directory where the generated code will be written`,
 			Aliases:     []string{"o"},
 			Destination: &c.output,
 			Value:       ".",

--- a/internal/shell/dboptions.go
+++ b/internal/shell/dboptions.go
@@ -1,0 +1,77 @@
+package shell
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/samber/lo"
+	"github.com/sclgo/usqlgen/internal/gen"
+	"github.com/urfave/cli/v2"
+)
+
+type dboption struct {
+	name  string
+	desc  string
+	apply func(input *gen.Input)
+}
+
+var (
+	allOptions = []*dboption{
+		{
+			name: "includesemicolon",
+			desc: `Include the trailing semicolon the usql uses to identify the end of a statement.
+usql normally includes them, but usqlgen doesn't by default because most Go drivers
+don't need or want trailing semicolons`,
+			apply: func(input *gen.Input) {
+				input.IncludeSemicolon = true
+			},
+		},
+	}
+	optionNames = lo.SliceToMap(allOptions, func(o *dboption) (string, *dboption) {
+		return o.name, o
+	})
+)
+
+func fromNames(names []string) ([]*dboption, error) {
+	var options []*dboption
+	for _, name := range names {
+		name = strings.ToLower(name)
+		opt, ok := optionNames[name]
+		if !ok {
+			return nil, fmt.Errorf("unknown option %s", name)
+		}
+		options = append(options, opt)
+	}
+	return options, nil
+}
+
+func applyOptionsFromNames(names []string, genInput *gen.Input) error {
+	activeOpts, err := fromNames(names)
+	if err != nil {
+		return err
+	}
+	lo.ForEach(activeOpts, func(item *dboption, _ int) {
+		item.apply(genInput)
+	})
+	return nil
+}
+
+func listOptions(c *cli.Context) error {
+	for _, opt := range allOptions {
+		err := writeOpt(opt, c.App.Writer)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func writeOpt(opt *dboption, writer io.Writer) error {
+	_, err := fmt.Fprint(writer, opt.name, "\n", "\n")
+	if err != nil {
+		return err
+	}
+	_, err = fmt.Fprintln(writer, opt.desc)
+	return err
+}

--- a/internal/shell/dboptions_test.go
+++ b/internal/shell/dboptions_test.go
@@ -1,0 +1,23 @@
+package shell
+
+import (
+	"testing"
+
+	"github.com/sclgo/usqlgen/internal/gen"
+	"github.com/stretchr/testify/require"
+)
+
+func TestApplyOptionsFromNames(t *testing.T) {
+	t.Run("cse insensitive", func(t *testing.T) {
+		genInput := gen.Input{}
+		err := applyOptionsFromNames([]string{"IncludeSemicoloN"}, &genInput)
+		require.NoError(t, err)
+		require.True(t, genInput.IncludeSemicolon)
+	})
+	t.Run("bad opt, good opt", func(t *testing.T) {
+		genInput := gen.Input{}
+		err := applyOptionsFromNames([]string{"includeSemicolon", "foobar"}, &genInput)
+		require.ErrorContains(t, err, "foobar")
+		require.False(t, genInput.IncludeSemicolon)
+	})
+}

--- a/internal/shell/run.go
+++ b/internal/shell/run.go
@@ -66,6 +66,18 @@ func makeApp(passthroughArgs []string, writer, errWriter io.Writer) *cli.App {
 				Flags:  commands.GenerateCmd.MakeFlags(),
 				Action: commands.GenerateCmd.Action,
 			},
+			{
+				Name:  "list",
+				Usage: "subcommands list various options and attributes",
+				Subcommands: []*cli.Command{
+					{
+						Name:   "options",
+						Usage:  "list options available for --dboptions parameter. Each option modifies how imported databases are treated.",
+						Args:   false,
+						Action: listOptions,
+					},
+				},
+			},
 		},
 	}
 	app.Usage = app.Description


### PR DESCRIPTION
Strip trailing semicolons by default. Add option to include them. See the added option description for rationale.
--db-option infrastructure is ready for new option e.g. skipinformationschema.