### PR TITLE
fix: prevent some built-in drivers being overwritten

### DIFF
--- a/internal/gen/gen_test.go
+++ b/internal/gen/gen_test.go
@@ -38,8 +38,10 @@ func TestInput_All(t *testing.T) {
 			Imports: []string{"github.com/MonetDB/MonetDB-Go/v2"},
 		}
 		stdoutStr := runGenAll(t, inp)
-		require.Contains(t, stdoutStr, "monetdb")
+		require.Contains(t, stdoutStr, "monetdb [mo]")
 		require.NotContains(t, stdoutStr, "github.com/MonetDB/MonetDB-Go/v2 v2.0.1")
+		// incorrectly re-registered sqlserver, which used to be a side-effect of imports
+		require.NotContains(t, stdoutStr, "mssql [ms]")
 	})
 
 	t.Run("replaces", func(t *testing.T) {

--- a/internal/integrationtest/impala/impala_test.go
+++ b/internal/integrationtest/impala/impala_test.go
@@ -29,20 +29,9 @@ func TestImpala(t *testing.T) {
 
 	dsn := GetDsn(ctx, t, c)
 
-	t.Run("kprotoss driver", func(t *testing.T) {
-		inp := gen.Input{
-			Imports: []string{"github.com/kprotoss/go-impala"},
-		}
-		t.Run("select", func(t *testing.T) {
-			integrationtest.CheckGenAll(t, inp, "impala:"+dsn, "select 'Hello World'")
-		})
-
-	})
-
 	t.Run("sclgo driver", func(t *testing.T) {
 		inp := gen.Input{
-			Imports:  []string{"github.com/bippio/go-impala"},
-			Replaces: []string{"github.com/bippio/go-impala=github.com/sclgo/go-impala@master"},
+			Imports: []string{"github.com/sclgo/impala-go"},
 		}
 
 		t.Run("select", func(t *testing.T) {
@@ -58,15 +47,6 @@ func TestImpala(t *testing.T) {
 
 			tableDdl := "create table default.dest(col1 string, col2 string) STORED AS PARQUET;"
 
-			//impala.DefaultOptions.LogOut = os.Stdout
-			//db, err := sql.Open("impala", dsn)
-			//require.NoError(t, err)
-			//defer sclerr.CloseQuietly(db)
-			//_, err = db.Exec(tableDdl)
-			//require.NoError(t, err)
-			//_, err = db.Exec("insert into default.dest values ('1', '2')")
-			//require.NoError(t, err)
-
 			output := integrationtest.RunGeneratedUsql(t, "impala:"+dsn, tableDdl, tmpDir)
 			require.Contains(t, output, "CREATE TABLE")
 
@@ -77,12 +57,9 @@ func TestImpala(t *testing.T) {
 
 			output = integrationtest.RunGeneratedUsql(t, "impala:"+dsn, "select * from dest", tmpDir)
 
-			//INSERT does not work on the combination current version of the driver and
-			//the docker environment. Writing to tables backed by local files requires passing the user
-			//which doesn't seem to happen when useLdap = false.
-			//require.Contains(t, output, "(1 row)")
-			require.Contains(t, output, "(0 rows)")
+			require.Contains(t, output, "(1 row)")
 		})
+
 	})
 
 	t.Run("kenshaw driver", func(t *testing.T) {

--- a/internal/integrationtest/monetdb/monetdb_test.go
+++ b/internal/integrationtest/monetdb/monetdb_test.go
@@ -36,6 +36,7 @@ func TestMonetdb(t *testing.T) {
 	}
 
 	integrationtest.CheckGenAll(t, inp, "monetdb:"+dsn, "select 1")
+	integrationtest.CheckGenAll(t, inp, "mo:"+dsn, "select 1")
 }
 
 func GetDsn(ctx context.Context, c testcontainers.Container) string {


### PR DESCRIPTION
Before this fix, mssql would incorrectly be replaced with a generic driver configuration, because it would appear as a new databases.

This fix also prevents the autogenerated two-letter alias to overwrite an exising alias.