### PR TITLE
feat: avoid downloading unnecessary dependencies

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -15,10 +15,10 @@ jobs:
     # ubuntu allows for docker support - https://docs.github.com/en/actions/using-containerized-services/about-service-containers
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4.2.2
 
     - name: Set up Go
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@v5.3.0
       with:
         go-version: '1.22'
 

--- a/internal/gen/gen_test.go
+++ b/internal/gen/gen_test.go
@@ -73,7 +73,7 @@ func runGenAll(t *testing.T, inp gen.Input) string {
 	err := inp.All()
 	require.NoError(t, err)
 
-	cmd := exec.Command("go", "run", ".", "-c", `\drivers`)
+	cmd := exec.Command("go", "run", "-mod=mod", ".", "-c", `\drivers`)
 	cmd.Dir = tmpDir
 	var buf bytes.Buffer
 	cmd.Stdout = io.MultiWriter(&buf, os.Stdout)

--- a/internal/integrationtest/build_test.go
+++ b/internal/integrationtest/build_test.go
@@ -44,5 +44,5 @@ func TestVersion(t *testing.T) {
 	cmd.Stderr = os.Stderr
 	require.NoError(t, cmd.Run())
 
-	require.Equal(t, fmt.Sprintf("usql %s-usqlgen", testVersion), strings.TrimSpace(buf.String()))
+	require.Equal(t, fmt.Sprintf("usql %s_usqlgen", testVersion), strings.TrimSpace(buf.String()))
 }

--- a/internal/integrationtest/common.go
+++ b/internal/integrationtest/common.go
@@ -57,7 +57,7 @@ func RunGeneratedUsqlE(dsn string, command string, tmpDir string, tags ...string
 		tags = []string{NoBaseTag}
 	}
 
-	cmd := exec.Command("go", "run", "-tags", strings.Join(tags, ","), ".", dsn, "-c", command)
+	cmd := exec.Command("go", "run", "-mod=mod", "-tags", strings.Join(tags, ","), ".", dsn, "-c", command)
 	cmd.Dir = tmpDir
 	var buf bytes.Buffer
 	cmd.Stdout = io.MultiWriter(&buf, os.Stdout)

--- a/internal/integrationtest/cosmos/cosmos_test.go
+++ b/internal/integrationtest/cosmos/cosmos_test.go
@@ -28,7 +28,7 @@ func TestCosmos(t *testing.T) {
 	err := inp.All()
 	require.NoError(t, err)
 
-	cmd := exec.Command("go", "run", "-tags", integrationtest.NoBaseTag, ".", "gocosmos:AccountEndpoint=https://localhost;AccountKey=test", "-c", `LIST DATABASES;`)
+	cmd := exec.Command("go", "run", "-mod=mod", "-tags", integrationtest.NoBaseTag, ".", "gocosmos:AccountEndpoint=https://localhost;AccountKey=test", "-c", `LIST DATABASES;`)
 	cmd.Dir = tmpDir
 	var buf bytes.Buffer
 	cmd.Stdout = io.Discard

--- a/internal/shell/cmd_build_test.go
+++ b/internal/shell/cmd_build_test.go
@@ -70,7 +70,23 @@ func TestBuild(t *testing.T) {
 		var buf bytes.Buffer
 		err := cmd.Action(&buf)
 		require.NoError(t, err)
-		require.Contains(t, buf.String(), testVersion+"-usqlgen")
+		require.Contains(t, buf.String(), testVersion+"_usqlgen")
+	})
+
+	t.Run("full build", func(t *testing.T) {
+		fi.SkipLongTest(t)
+
+		cmd := NewCommands(nil).BuildCmd
+		require.NoError(t, cmd.Imports.Set("github.com/sclgo/impala-go"))
+
+		currentWorkDir := fi.NoError(os.Getwd()).Require(t)
+		defer fi.NoErrorF(fi.Bind(os.Chdir, currentWorkDir), t)
+		require.NoError(t, os.Chdir(tmpDir))
+		err := cmd.Action(nil)
+		require.NoError(t, err)
+
+		outputTmpFile := filepath.Join(tmpDir, "usql")
+		checkExecutable(t, outputTmpFile)
 	})
 }
 

--- a/internal/shell/run_test.go
+++ b/internal/shell/run_test.go
@@ -2,12 +2,13 @@ package shell_test
 
 import (
 	"bytes"
+	"testing"
+
 	"github.com/sclgo/usqlgen/internal/shell"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
-func TestGenerate(t *testing.T) {
+func TestRunArgs(t *testing.T) {
 	var buf bytes.Buffer
 	shell.RunArgs([]string{"usqlgen", "generate", "--help"}, &buf, nil)
 	require.Contains(t, buf.String(), "generate")


### PR DESCRIPTION
Avoid running `go mod tidy` when building with `--import` only. `go mod tidy` pulls transitive test dependencies which are not needed just to build usql - https://go.dev/wiki/Modules#why-does-go-mod-tidy-record-indirect-and-test-dependencies-in-my-gomod 

The change speeds up significantly the `build` and `install` commands reduces the amount of bandwidth used. For example, for `--import github.com/sclgo/impala-go` this approach leads to 521 MB of Go mod cache, measured on a clean `golang:1.24` container with

```shell
du -sh $(go env GOMODCACHE)
```

as opposed to 3.1 GB with latest release - **6x improvement**.

Time improvement on my machine is 44 sec on this branch vs. 56 sec on latest. The time improvement varies though based on the bandwidth. There is little improvement in pipeline time because actions/setup-go caches modules across runs. Still the Post step of setup-go is sec faster in part because the cache is smaller - 2.1 GB vs 2.6 GB.

The PR also upgrades actions/setup-go from 4 to 5.3.0 with huge improvement in time spent there - 3 min less. actions/checkout is also updated.

Finally, the PR removes the `go mod edit -go=1.23` command which is not needed with recent versions of `usql` . It is left commented out in case someone wants to use an old usql version.
