### PR TITLE
optimization: don't mess with main() if no imports

### DIFF
--- a/internal/gen/gen_test.go
+++ b/internal/gen/gen_test.go
@@ -22,13 +22,6 @@ func TestInput_Main(t *testing.T) {
 		require.NoError(t, inp.Main(&buf))
 		require.Contains(t, buf.String(), "hello/hello")
 	})
-
-	t.Run("without imports", func(t *testing.T) {
-		var inp gen.Input
-		buf := bytes.Buffer{}
-		require.NoError(t, inp.Main(&buf))
-		require.NotContains(t, buf.String(), "RegisterNewDrivers")
-	})
 }
 
 func TestInput_All(t *testing.T) {

--- a/internal/gen/main.go.tpl
+++ b/internal/gen/main.go.tpl
@@ -1,6 +1,5 @@
 package main
 
-{{if .Imports}}
 import (
 	"maps"
 	"slices"
@@ -9,14 +8,12 @@ import (
 	"github.com/xo/usql/env"
 	"github.com/xo/dburl"
 )
-{{end}}
 
 {{range $val := .Imports}}
 import _ "{{$val}}"
 {{end}}
 
 func main() {
-{{if .Imports}}
 	newDrivers := gen.RegisterNewDrivers(slices.Collect(maps.Keys(drivers.Available())))
 	for _, driver := range newDrivers {
 		drivers.Register(driver, drivers.Driver{
@@ -32,6 +29,5 @@ func main() {
 	}
 	// The default prompt is sometimes too long for DBs with opaque URLs
 	env.Set("PROMPT1", "%S%N%m%R%# ")
-{{end}}
 	origMain()
 }

--- a/internal/integrationtest/common.go
+++ b/internal/integrationtest/common.go
@@ -2,8 +2,6 @@ package integrationtest
 
 import (
 	"bytes"
-	"context"
-	"database/sql"
 	"io"
 	"os"
 	"os/exec"
@@ -12,7 +10,6 @@ import (
 	"testing"
 
 	"github.com/sclgo/usqlgen/internal/gen"
-	"github.com/sclgo/usqlgen/pkg/sclerr"
 	"github.com/stretchr/testify/require"
 )
 
@@ -25,13 +22,15 @@ func IntegrationOnly(t *testing.T) {
 	}
 }
 
-func SanityPing(ctx context.Context, t *testing.T, dsn string, driver string) {
-	db, err := sql.Open(driver, dsn)
-	require.NoError(t, err)
-	defer sclerr.CloseQuietly(db)
-	err = db.PingContext(ctx)
-	require.NoError(t, err)
-}
+//SanityPing pings a DB identified by driver and dsn directly through database/sql
+//It is avoided in regularly executed tests because it requires an explicit dependency to the DB driver
+//func SanityPing(ctx context.Context, t *testing.T, dsn string, driver string) {
+//	db, err := sql.Open(driver, dsn)
+//	require.NoError(t, err)
+//	defer sclerr.CloseQuietly(db)
+//	err = db.PingContext(ctx)
+//	require.NoError(t, err)
+//}
 
 func CheckGenAll(t *testing.T, inp gen.Input, dsn string, command string, tags ...string) {
 	tmpDir := t.TempDir()


### PR DESCRIPTION
Since the changes to main() are no-op if there are no imports, don't run them at all, instead of having checks inside the .tpl file.