### PR TITLE
feat: automate replacement for sqlite

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -11,8 +11,8 @@ on:
 
 jobs:
 
-  build:
-    # ubuntu allows for docker support - https://docs.github.com/en/actions/using-containerized-services/about-service-containers
+  e2e:
+    # Only ubuntu allows for docker support - https://docs.github.com/en/actions/using-containerized-services/about-service-containers
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4.2.2
@@ -20,15 +20,26 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5.3.0
       with:
-        go-version: '1.22'
+        go-version: '1.23'
 
     - name: Build
       run: go build -v ./...
-    # - name: Configure git for private modules
-    #   env:
-    #     TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
-    #   run: git config --global url."https://murfffi:${TOKEN}@github.com".insteadOf "https://github.com"
     - name: Test
       run: make test
-    - name: Integration
+    - name: Integration # requires Docker and thus ubuntu runner
       run: make itest
+
+  platforms:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os:
+          - "windows-latest"
+          - "macos-latest"
+    steps:
+      - uses: actions/checkout@v4.2.2
+      - uses: actions/setup-go@v5.3.0
+        with:
+          go-version: '1.21'
+      - name: Test
+        run: make test

--- a/internal/gen/gen.go
+++ b/internal/gen/gen.go
@@ -126,7 +126,7 @@ func (i Input) AllDownload() (Result, error) {
 	if !i.KeepCgo {
 		adjustErr := i.adjustCgoTags()
 		if adjustErr != nil {
-			i.log("Failed to adjust base cgo tags, but this might not be an issue, depending on tags and environment. Cause: %v", err)
+			i.log("Failed to adjust base cgo tags, but this might not be an issue, depending on tags and environment. Cause: %v", adjustErr)
 		}
 	}
 

--- a/internal/gen/gen.go
+++ b/internal/gen/gen.go
@@ -298,16 +298,6 @@ func (i Input) log(msg string, args ...any) {
 	_, _ = fmt.Fprintf(os.Stderr, msg, args...)
 }
 
-func (i Input) editSqlite3Import() error {
-	origFile := filepath.Join(i.WorkingDir)
-	inp, err := os.Open(origFile)
-	if err != nil {
-		return merry.Wrap(err)
-	}
-	defer sclerr.CloseQuietly(inp)
-	return nil
-}
-
 // We believe that we don't need to go get the --imports params,
 // since this is handled by CompileCmd using either -mod=mod for build/install,
 // or "go mod tidy for generate

--- a/internal/gen/gen.go
+++ b/internal/gen/gen.go
@@ -41,6 +41,7 @@ type Input struct {
 	USQLVersion string
 
 	IncludeSemicolon bool
+	KeepCgo          bool
 }
 
 type Result struct {
@@ -68,10 +69,14 @@ func (i Input) AllDownload() (Result, error) {
 	err = cmd.Run()
 	if err != nil {
 		var exitErr *exec.ExitError
-		if !errors.As(err, &exitErr) || exitErr.ExitCode() != 1 {
-			return result, merry.Wrap(err, merry.AppendMessagef("while running go mod download with output \n%s", &errorBuf))
+		if !errors.As(err, &exitErr) || exitErr.ExitCode() != 1 || outputBuf.Len() > 0 {
+			return result, merry.Wrap(err, merry.AppendMessagef("while running go mod download with stdout length %d and stderr output \n%s", outputBuf.Len(), &errorBuf))
 		}
-		// https://github.com/golang/go/issues/35380
+		// We ignore exit code 1 with non-empty output, because this indicates a partial success of
+		// go mod download command and that the package was likely successfully downloaded.
+		// This case happens frequently.
+		// https://github.com/golang/go/issues/35380 is about a different issue but some comments
+		// cover this case.
 	}
 
 	var downloadInfo map[string]any
@@ -116,6 +121,13 @@ func (i Input) AllDownload() (Result, error) {
 	err = i.goModReplace(i.Replaces)
 	if err != nil {
 		return result, err
+	}
+
+	if !i.KeepCgo {
+		adjustErr := i.adjustCgoTags()
+		if adjustErr != nil {
+			i.log("Failed to adjust base cgo tags, but this might not be an issue, depending on tags and environment. Cause: %v", err)
+		}
 	}
 
 	return result, err
@@ -249,24 +261,51 @@ func (i Input) doGoGet() error {
 	return doGoGet(i.Gets, i)
 }
 
-func (i Input) editOriginalMain() error {
-	origMainFile := filepath.Join(i.WorkingDir, "main.go")
+func (i Input) replaceInUsqlFile(relPath string, before string, after string) error {
+	origMainFile := filepath.Join(i.WorkingDir, relPath)
 	origMainBytes, err := os.ReadFile(origMainFile)
 	if err != nil {
 		return merry.Wrap(err)
 	}
-	origMainBytes = bytes.Replace(origMainBytes, []byte("func main()"), []byte("func origMain()"), 1)
+	origMainBytes = bytes.Replace(origMainBytes, []byte(before), []byte(after), 1)
 	err = os.WriteFile(origMainFile, origMainBytes, fileMode)
 	return merry.Wrap(err)
 }
 
 func (i Input) replaceMain() error {
-	err := i.editOriginalMain()
+	err := i.replaceInUsqlFile("main.go", "func main()", "func origMain()")
 	if err != nil {
 		return err
 	}
 
 	return i.populateMain()
+}
+
+func (i Input) adjustCgoTags() error {
+	err := i.replaceInUsqlFile(filepath.Join("internal", "sqlite3.go"), "!no_base", "!no_base && cgo")
+	if err != nil {
+		return err
+	}
+	moderncsqliteHookPath := filepath.Join("internal", "moderncsqlite.go")
+	// we must include moderncsqlite *only* if sqlite3 was excluded because of !go
+	return i.replaceInUsqlFile(moderncsqliteHookPath, "most", "most || (!cgo && !no_base && !no_sqlite3)")
+
+	// usql already contains code that assigns sqlite3 aliases to moderncsqlite,
+	// if moderncsqlite is present but sqlite3 is not - usql/internal/z.go
+}
+
+func (i Input) log(msg string, args ...any) {
+	_, _ = fmt.Fprintf(os.Stderr, msg, args...)
+}
+
+func (i Input) editSqlite3Import() error {
+	origFile := filepath.Join(i.WorkingDir)
+	inp, err := os.Open(origFile)
+	if err != nil {
+		return merry.Wrap(err)
+	}
+	defer sclerr.CloseQuietly(inp)
+	return nil
 }
 
 // We believe that we don't need to go get the --imports params,

--- a/internal/gen/main.go.tpl
+++ b/internal/gen/main.go.tpl
@@ -7,6 +7,8 @@ import (
 	"github.com/xo/usql/drivers"
 	"github.com/xo/usql/env"
 	"github.com/xo/dburl"
+
+	_ "github.com/xo/usql/internal"
 )
 
 {{range $val := .Imports}}

--- a/internal/integrationtest/clickhouse/clickhouse_test.go
+++ b/internal/integrationtest/clickhouse/clickhouse_test.go
@@ -41,7 +41,7 @@ func TestClickhouse(t *testing.T) {
 		err := inp.All()
 		require.NoError(t, err)
 
-		_, _ = it.RunGeneratedUsqlE(dsn, "create table dest(col1 varchar, col2 varchar) PRIMARY KEY col1;", tmpDir)
+		_, _ = it.RunGeneratedUsqlE(dsn, "create table dest(col1 varchar, col2 varchar) PRIMARY KEY col1;", tmpDir, nil)
 		// ignoring error because usql -c, for some reason, fails if RowsAffected returns error
 		// chhttp returns error from RowsAffected because it doesn't support it
 

--- a/internal/integrationtest/common.go
+++ b/internal/integrationtest/common.go
@@ -45,12 +45,12 @@ func CheckGenAll(t *testing.T, inp gen.Input, dsn string, command string, tags .
 
 func RunGeneratedUsql(t *testing.T, dsn string, command string, tmpDir string, tags ...string) string {
 	t.Logf("Running cmd %s with dsn %s", command, dsn)
-	output, err := RunGeneratedUsqlE(dsn, command, tmpDir, tags...)
+	output, err := RunGeneratedUsqlE(dsn, command, tmpDir, nil, tags...)
 	require.NoError(t, err)
 	return output
 }
 
-func RunGeneratedUsqlE(dsn string, command string, tmpDir string, tags ...string) (string, error) {
+func RunGeneratedUsqlE(dsn string, command string, tmpDir string, addEnv []string, tags ...string) (string, error) {
 	// speed up build, add some tag like "base" to disable
 	if tags == nil {
 		tags = []string{NoBaseTag}
@@ -64,6 +64,7 @@ func RunGeneratedUsqlE(dsn string, command string, tmpDir string, tags ...string
 	cmd.Env = slices.DeleteFunc(os.Environ(), func(s string) bool {
 		return strings.HasPrefix(s, "GO")
 	})
+	cmd.Env = append(cmd.Env, addEnv...)
 	err := cmd.Run()
 	output := buf.String()
 	return output, err

--- a/internal/integrationtest/sqlite/sqlite_cgo_test.go
+++ b/internal/integrationtest/sqlite/sqlite_cgo_test.go
@@ -1,0 +1,24 @@
+//go:build cgo
+
+package sqlite
+
+import (
+	"testing"
+
+	"github.com/sclgo/usqlgen/internal/gen"
+	it "github.com/sclgo/usqlgen/internal/integrationtest"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSqliteCgo(t *testing.T) {
+	inp := gen.Input{}
+
+	tmpDir := t.TempDir()
+	inp.WorkingDir = tmpDir
+
+	err := inp.All()
+	require.NoError(t, err)
+
+	output := it.RunGeneratedUsql(t, "sqlite3::memory:", `select sqlite_version()`, tmpDir, "no_moderncsqlite")
+	require.Contains(t, output, "sqlite_version()")
+}

--- a/internal/integrationtest/sqlite/sqlite_test.go
+++ b/internal/integrationtest/sqlite/sqlite_test.go
@@ -1,6 +1,7 @@
 package sqlite
 
 import (
+	"runtime"
 	"testing"
 
 	"github.com/sclgo/usqlgen/internal/gen"
@@ -12,10 +13,13 @@ import (
 // The tests that require CGO must be skipped - not failed - on systems without CGO.
 // CGO tests go in sqlite_cgo_test.go
 
-func TestSqlite(t *testing.T) {
+func TestSqlite_NoCgo(t *testing.T) {
+	if runtime.GOOS == "darwin" {
+		t.Skip("Skipping on No CGO test on MacOS due to https://github.com/jeandeaual/go-locale/issues/30#issuecomment-2798583087")
+	}
 	noCgoEnv := []string{"CGO_ENABLED=0"}
 
-	t.Run("no_cgo_base", func(t *testing.T) {
+	t.Run("base", func(t *testing.T) {
 		// Confirm that base driver set supports sqlite3 schema (via a replacement) even
 		// if original sqlite3 is not available due to no CGO
 		tag := "base"
@@ -35,7 +39,7 @@ func TestSqlite(t *testing.T) {
 		require.Contains(t, output, "sqlite_version()")
 	})
 
-	t.Run("no_cgo_no_replacement", func(t *testing.T) {
+	t.Run("no_replacement", func(t *testing.T) {
 		// Check that replacement logic obeys the tags that block sqlite3 replacement
 		for _, tag := range []string{"no_base", "no_moderncsqlite", "no_sqlite3"} {
 			t.Run(tag, func(t *testing.T) {
@@ -57,7 +61,7 @@ func TestSqlite(t *testing.T) {
 		}
 	})
 
-	t.Run("no_cgo_keepcgo", func(t *testing.T) {
+	t.Run("keepcgo", func(t *testing.T) {
 		// Check that
 		inp := gen.Input{
 			KeepCgo: true,

--- a/internal/integrationtest/sqlite/sqlite_test.go
+++ b/internal/integrationtest/sqlite/sqlite_test.go
@@ -1,0 +1,75 @@
+package sqlite
+
+import (
+	"testing"
+
+	"github.com/sclgo/usqlgen/internal/gen"
+	it "github.com/sclgo/usqlgen/internal/integrationtest"
+	"github.com/stretchr/testify/require"
+)
+
+// This file can't contain any tests that require CGO.
+// The tests that require CGO must be skipped - not failed - on systems without CGO.
+// CGO tests go in sqlite_cgo_test.go
+
+func TestSqlite(t *testing.T) {
+	noCgoEnv := []string{"CGO_ENABLED=0"}
+
+	t.Run("no_cgo_base", func(t *testing.T) {
+		// Confirm that base driver set supports sqlite3 schema (via a replacement) even
+		// if original sqlite3 is not available due to no CGO
+		tag := "base"
+		inp := gen.Input{}
+
+		tmpDir := t.TempDir()
+		inp.WorkingDir = tmpDir
+
+		err := inp.All()
+		require.NoError(t, err)
+
+		_, err = it.RunGeneratedUsqlE("", `\drivers`, tmpDir, noCgoEnv, tag)
+		require.NoError(t, err)
+
+		output, err := it.RunGeneratedUsqlE("sqlite3::memory:", `select sqlite_version()`, tmpDir, noCgoEnv, tag)
+		require.NoError(t, err)
+		require.Contains(t, output, "sqlite_version()")
+	})
+
+	t.Run("no_cgo_no_replacement", func(t *testing.T) {
+		// Check that replacement logic obeys the tags that block sqlite3 replacement
+		for _, tag := range []string{"no_base", "no_moderncsqlite", "no_sqlite3"} {
+			t.Run(tag, func(t *testing.T) {
+				inp := gen.Input{}
+
+				tmpDir := t.TempDir()
+				t.Log(tmpDir)
+				inp.WorkingDir = tmpDir
+
+				err := inp.All()
+				require.NoError(t, err)
+
+				_, err = it.RunGeneratedUsqlE("", `\drivers`, tmpDir, noCgoEnv, tag)
+				require.NoError(t, err)
+
+				_, err = it.RunGeneratedUsqlE("sqlite3::memory:", `select sqlite_version()`, tmpDir, noCgoEnv, tag)
+				require.Error(t, err)
+			})
+		}
+	})
+
+	t.Run("no_cgo_keepcgo", func(t *testing.T) {
+		// Check that
+		inp := gen.Input{
+			KeepCgo: true,
+		}
+
+		tmpDir := t.TempDir()
+		inp.WorkingDir = tmpDir
+
+		err := inp.All()
+		require.NoError(t, err)
+
+		_, err = it.RunGeneratedUsqlE("", `\drivers`, tmpDir, noCgoEnv, "base")
+		require.Error(t, err)
+	})
+}

--- a/internal/shell/cmd_build_test.go
+++ b/internal/shell/cmd_build_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/sclgo/usqlgen/internal/gen"
@@ -95,8 +96,10 @@ func checkExecutable(t *testing.T, path string) {
 	require.NoError(t, err)
 	result, err := exec.Command("file", path).Output()
 	require.NoError(t, err)
-	require.Contains(t, string(result), "LSB executable")
-	require.Contains(t, string(result), "ELF")
+	if runtime.GOOS == "linux" {
+		require.Contains(t, string(result), "LSB executable")
+		require.Contains(t, string(result), "ELF")
+	}
 }
 
 func minimalCompileCommand() CompileCommand {

--- a/internal/shell/dboptions.go
+++ b/internal/shell/dboptions.go
@@ -20,11 +20,19 @@ var (
 	allOptions = []*dboption{
 		{
 			name: "includesemicolon",
-			desc: `Include the trailing semicolon the usql uses to identify the end of a statement.
-usql normally includes them, but usqlgen doesn't by default because most Go drivers
-don't need or want trailing semicolons`,
+			desc: `Include the trailing semicolon that usql uses to identify the end of a statement,
+in the SQL string sent to the driver. usql normally includes them, but usqlgen doesn't by
+default because most Go drivers don't need or want trailing semicolons.`,
 			apply: func(input *gen.Input) {
 				input.IncludeSemicolon = true
+			},
+		},
+		{
+			name: "keepcgo",
+			desc: `Don't replace drivers that require CGO if CGO is not available. Compilation will likely fail.
+Useful if generation happens in one environment but compilation in another. See docs for details.`,
+			apply: func(input *gen.Input) {
+				input.KeepCgo = true
 			},
 		},
 	}
@@ -58,8 +66,13 @@ func applyOptionsFromNames(names []string, genInput *gen.Input) error {
 }
 
 func listOptions(c *cli.Context) error {
+	_, err := fmt.Fprint(c.App.Writer, "Options available for --dboptions parameter:\n\n")
+	if err != nil {
+		return err
+	}
+
 	for _, opt := range allOptions {
-		err := writeOpt(opt, c.App.Writer)
+		err = writeOpt(opt, c.App.Writer)
 		if err != nil {
 			return err
 		}
@@ -68,10 +81,10 @@ func listOptions(c *cli.Context) error {
 }
 
 func writeOpt(opt *dboption, writer io.Writer) error {
-	_, err := fmt.Fprint(writer, opt.name, "\n", "\n")
+	_, err := fmt.Fprint(writer, "- ", opt.name, "\n", "\n")
 	if err != nil {
 		return err
 	}
-	_, err = fmt.Fprintln(writer, opt.desc)
+	_, err = fmt.Fprint(writer, opt.desc, "\n", "\n")
 	return err
 }

--- a/internal/shell/run.go
+++ b/internal/shell/run.go
@@ -72,7 +72,7 @@ func makeApp(passthroughArgs []string, writer, errWriter io.Writer) *cli.App {
 				Subcommands: []*cli.Command{
 					{
 						Name:   "options",
-						Usage:  "list options available for --dboptions parameter. Each option modifies how imported databases are treated.",
+						Usage:  "displays options available for --dboptions parameter. Each option modifies how database drivers are treated.",
 						Args:   false,
 						Action: listOptions,
 					},


### PR DESCRIPTION
usql assigns that sqlite3 alias to moderncsqlite, if the former driver is excluded, but the later is available. usqlgen builds on that feature to automatically exclude sqlite3, and include moderncsqlite in the base set of drivers if cgo is not available.