### PR TITLE
feat: add troubleshooting signal handlers to usqlgen

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ go run github.com/sclgo/usqlgen@latest build
 ```
 
 `usqlgen` can also be used to add to `usql` packages that don't register drivers but provide some other
-useful import side effects. For example, [github.com/tam7t/sigprof](https://github.com/tam7t/sigprof) adds
+useful import side effects. For example, on Linux and MacOS, [github.com/tam7t/sigprof](https://github.com/tam7t/sigprof) adds
 helpful signal handlers for troubleshooting - `usqlgen` itself is using it. Example command:
 
 Note that if none of the packages that you imported registered any drivers, you will see a warning
@@ -280,7 +280,7 @@ pkill -USR1 usqlgen
 
 The program *won't* exit!
 
-`usqlgen` uses the `sigprof` library to implement this feature. Review 
+On Linux and MacOS, `usqlgen` uses the `sigprof` library to implement this feature. Review 
 [its documentation](https://github.com/tam7t/sigprof) for other troubleshooting options it provides in `usqlgen`.
 
 Besides that, `usqlgen` supports standard options for troubleshooting Golang applications e.g.

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/murfffi/gorich v0.1.0
 	github.com/samber/lo v1.49.1
 	github.com/stretchr/testify v1.10.0
+	github.com/tam7t/sigprof v0.0.0-20160401200512-7750edaf4b70
 	github.com/testcontainers/testcontainers-go v0.35.0
 	github.com/urfave/cli/v2 v2.27.5
 	github.com/xo/dburl v0.23.3

--- a/go.sum
+++ b/go.sum
@@ -133,6 +133,8 @@ github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/tam7t/sigprof v0.0.0-20160401200512-7750edaf4b70 h1://B0tuvK8089zvmKDCjwq7JA5+4r4+Qa8S7Eyg291Vg=
+github.com/tam7t/sigprof v0.0.0-20160401200512-7750edaf4b70/go.mod h1:acozF9MOzkEVagOQ1AbK6QFkmdy/5N8Ox3dxLXbrvZE=
 github.com/testcontainers/testcontainers-go v0.35.0 h1:uADsZpTKFAtp8SLK+hMwSaa+X+JiERHtd4sQAFmXeMo=
 github.com/testcontainers/testcontainers-go v0.35.0/go.mod h1:oEVBj5zrfJTrgjwONs1SsRbnBtH9OKl+IGl3UMcr2B4=
 github.com/tklauser/go-sysconf v0.3.14 h1:g5vzr9iPFFz24v2KZXs/pvpvh8/V9Fw6vQK5ZZb78yU=

--- a/internal/gen/main.go.tpl.go
+++ b/internal/gen/main.go.tpl.go
@@ -27,7 +27,7 @@ import _ "{{$val}}"
 
 func main() {
 	newDrivers := gen.RegisterNewDrivers(slices.Collect(maps.Keys(drivers.Available())))
-	if newDrivers == nil && {{len .Imports}} > 0 {
+	if len(newDrivers) == 0 && {{len .Imports}} > 0 {
 		fmt.Println("Did not find new drivers in packages {{ .Imports }}. " +
 			"Either the packages don't register drivers or an imported driver name clashes with existing drivers or their aliases. " +
 			"In the latter case, try adding '-- -tags no_xxx' to the usqlgen command-line, where xxx is a DB tag from usql docs.")

--- a/main.go
+++ b/main.go
@@ -1,12 +1,6 @@
 package main
 
-import (
-	// for USR1 (stack trace) and USR2 (heap profile) signals.
-	// See README for usage.
-	_ "github.com/tam7t/sigprof"
-
-	"github.com/sclgo/usqlgen/internal/shell"
-)
+import "github.com/sclgo/usqlgen/internal/shell"
 
 func main() {
 	shell.Run()

--- a/main.go
+++ b/main.go
@@ -1,8 +1,8 @@
 package main
 
 import (
-	// for USR1, USR2 handling e.g. "pkill -USR1 usqlgen" prints stacktrace
-	// see docs for details
+	// for USR1 (stack trace) and USR2 (heap profile) signals.
+	// See README for usage.
 	_ "github.com/tam7t/sigprof"
 
 	"github.com/sclgo/usqlgen/internal/shell"

--- a/main.go
+++ b/main.go
@@ -1,6 +1,12 @@
 package main
 
-import "github.com/sclgo/usqlgen/internal/shell"
+import (
+	// for USR1, USR2 handling e.g. "pkill -USR1 usqlgen" prints stacktrace
+	// see docs for details
+	_ "github.com/tam7t/sigprof"
+
+	"github.com/sclgo/usqlgen/internal/shell"
+)
 
 func main() {
 	shell.Run()

--- a/signals_unix.go
+++ b/signals_unix.go
@@ -3,7 +3,7 @@
 package main
 
 import (
-	// for USR1, USR2 handling e.g. "pkill -USR1 usqlgen" prints stacktrace
-	// see docs for details
+	// for USR1 (stack trace) and USR2 (heap profile) signals.
+	// See README for usage.
 	_ "github.com/tam7t/sigprof"
 )

--- a/signals_unix.go
+++ b/signals_unix.go
@@ -1,0 +1,9 @@
+//go:build unix
+
+package main
+
+import (
+	// for USR1, USR2 handling e.g. "pkill -USR1 usqlgen" prints stacktrace
+	// see docs for details
+	_ "github.com/tam7t/sigprof"
+)


### PR DESCRIPTION
also adds docs how to get the same signal handlers in the produced usql distributions

fixes an issue, possible regression, in the code that warns if no drivers were registered